### PR TITLE
to_ascii_lower -> String#into_ascii_lower to match Rust nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ extern crate log;
 #[cfg(test)]
 extern crate test;
 
-use std::ascii::OwnedAsciiExt;
+use std::ascii::AsciiExt;
 use std::cmp::Equiv;
 use std::fmt;
 use std::from_str::FromStr;
@@ -164,7 +164,7 @@ impl fmt::Show for Mime {
 
 impl FromStr for Mime {
     fn from_str(raw: &str) -> Option<Mime> {
-        let ascii = raw.to_string().into_ascii_lower(); // lifetimes :(
+        let ascii = raw.to_ascii_lower(); // lifetimes :(
         let raw = ascii.as_slice();
         let len = raw.len();
         let mut iter = raw.chars().enumerate();


### PR DESCRIPTION
I am unable to compile mime against Rust nightly, I get:

```
src/encoding/label.rs:7:5: 7:28 error: unresolved import `std::ascii::StrAsciiExt`. There is no `StrAsciiExt` in `std::ascii`
src/encoding/label.rs:7 use std::ascii::StrAsciiExt;
                            ^~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
Build failed, waiting for other jobs to finish...
/Users/john/.cargo/git/checkouts/mime.rs-bb2736419bbdb48d/master/src/lib.rs:28:5: 28:28 error: unresolved import `std::ascii::StrAsciiExt`. There is no `StrAsciiExt` in `std::ascii`
/Users/john/.cargo/git/checkouts/mime.rs-bb2736419bbdb48d/master/src/lib.rs:28 use std::ascii::StrAsciiExt;
                                                                                   ^~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
Could not compile `encoding`.
```

This is a quick patch to update the use of to_ascii_lower to use into_ascii_lower on String
