### PR TITLE
to_ascii_lower() -> to_ascii_lowercase() change to compile on master

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ impl fmt::Show for Mime {
 
 impl FromStr for Mime {
     fn from_str(raw: &str) -> Option<Mime> {
-        let ascii = raw.to_ascii_lower(); // lifetimes :(
+        let ascii = raw.to_ascii_lowercase(); // lifetimes :(
         let raw = ascii.as_slice();
         let len = raw.len();
         let mut iter = raw.chars().enumerate();


### PR DESCRIPTION
Just a minor change in method name. I assume this repo tracks master.
