### PR TITLE
impl Into<str> for Name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,7 +451,7 @@ impl<'a> AsRef<str> for Name<'a> {
 impl<'a> From<Name<'a>> for &'a str {
     #[inline]
     fn from(name: Name<'a>) -> &'a str {
-        self.source
+        name.source
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,17 @@ fn name_eq_str(name: &Name, s: &str) -> bool {
     }
 }
 
+impl<'a> Name<'a> {
+    /// Get the value of this `Name` as a string.
+    ///
+    /// Note that the borrow is not tied to `&self` but the `'a` lifetime, allowing the
+    /// string to outlive `Name`. Alternately, there is an `impl<'a> From<Name<'a>> for &'a str`
+    /// which isn't rendered by Rustdoc, that can be accessed using `str::from(name)` or `name.into()`.
+    pub fn as_str(&self) -> &'a str {
+        self.source
+    }
+}
+
 impl<'a, 'b> PartialEq<&'b str> for Name<'a> {
     #[inline]
     fn eq(&self, other: & &'b str) -> bool {
@@ -437,9 +448,9 @@ impl<'a> AsRef<str> for Name<'a> {
     }
 }
 
-impl<'a> Into<&'a str> for Name<'a> {
+impl<'a> From<Name<'a>> for &'a str {
     #[inline]
-    fn into(self) -> &'a str {
+    fn from(name: Name<'a>) -> &'a str {
         self.source
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,13 @@ impl<'a> AsRef<str> for Name<'a> {
     }
 }
 
+impl<'a> Into<&'a str> for Name<'a> {
+    #[inline]
+    fn into(self) -> &'a str {
+        self.source
+    }
+}
+
 impl<'a> fmt::Debug for Name<'a> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
This should still be workable if/when the source is changed as per the `TODO`

cc @seanmonstar Mind publishing a new version before/after this? I think `0.3.4` would be compatible as per the semver spec.