### PR TITLE
Add test for params method of Mime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -829,6 +829,23 @@ mod tests {
     }
 
     #[test]
+    fn test_params() {
+        let mime = TEXT_PLAIN;
+        let mut params = mime.params();
+        assert_eq!(params.next(), None);
+
+        let mime = Mime::from_str("text/plain; charset=utf-8; foo=bar").unwrap();
+        let mut params = mime.params();
+        assert_eq!(params.next(), Some((CHARSET, UTF_8)));
+
+        let (second_param_left, second_param_right) = params.next().unwrap();
+        assert_eq!(second_param_left, "foo");
+        assert_eq!(second_param_right, "bar");
+
+        assert_eq!(params.next(), None);
+    }
+
+    #[test]
     fn test_name_eq() {
         assert_eq!(TEXT, TEXT);
         assert_eq!(TEXT, "text");


### PR DESCRIPTION
I noticed that Mime::params() does not get tested directly although it is part of the public API.

The test for `get_param` already indirectly covers the params method because the implementation uses it internally. This could be too much duplicate test coverage.

I also could adapt the current test into a documentation test as there is none at the moment.

Happy to hear feedback!