### PR TITLE
Add tar MIME

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,6 +506,7 @@ names! {
     WWW_FORM_URLENCODED, "x-www-form-urlencoded";
     MSGPACK, "msgpack";
     OCTET_STREAM, "octet-stream";
+    TAR, "tar";
 
     // multipart/*
     FORM_DATA, "form-data";
@@ -660,6 +661,7 @@ mimes! {
     APPLICATION_WWW_FORM_URLENCODED, "application/x-www-form-urlencoded", 11;
     APPLICATION_OCTET_STREAM, "application/octet-stream", 11;
     APPLICATION_MSGPACK, "application/msgpack", 11;
+    APPLICATION_TAR, "application/x-tar", 11;
 
     MULTIPART_FORM_DATA, "multipart/form-data", 9;
 }


### PR DESCRIPTION
This PR adds a MIME type for `tar`, quite commonly used on Linux/Unix systems.

The tar type information is used from: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types