### PR TITLE
Add an IMAGE_SVG constant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,7 +538,7 @@ names! {
 pub static UTF_8: Value = Value { source: "utf-8", ascii_case_insensitive: true };
 
 macro_rules! mimes {
-    ($($id:ident, $($piece:tt),*;)*) => (
+    ($($id:ident, $($piece:expr),*;)*) => (
         #[allow(non_camel_case_types)]
         enum __Atoms {
             __Dynamic,
@@ -653,6 +653,7 @@ mimes! {
     IMAGE_GIF, "image/gif", 5;
     IMAGE_PNG, "image/png", 5;
     IMAGE_BMP, "image/bmp", 5;
+    IMAGE_SVG, "image/svg+xml", 5, Some(9);
 
     APPLICATION_JSON, "application/json", 11;
     APPLICATION_JAVASCRIPT, "application/javascript", 11;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -555,7 +555,7 @@ macro_rules! mimes {
 
         #[test]
         fn test_mimes_macro_consts() {
-            [
+            let _ = [
             $(
             mime_constant_test! {
                 $id, $($piece),*


### PR DESCRIPTION
I need a svg mime type that can be referenced in constant expressions, so I propose adding IMAGE_SVG along with other mime-type constants here.

Since the correct mime type for svg is `image/svg+xml`, a plus position needed to be present in the declaration.  That meant I had to change the type of pieces in the macro from `tt` to `expr`.