### PR TITLE
Fix test_mimes_macro_consts.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -555,7 +555,7 @@ macro_rules! mimes {
 
         #[test]
         fn test_mimes_macro_consts() {
-            [
+            let _ = [
             $(
             mime_constant_test! {
                 $id, $($piece),*


### PR DESCRIPTION
Put the result in an underscore variable so the compiler doesn't complain that it is unused.

This fixes #85 .