### PR TITLE
Bump unicase to a working version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ keywords = ["mime", "media-extensions", "media-types"]
 publish = false # breaking changes from 0.3.x
 
 [dependencies]
-unicase = "2.0"
+unicase = "2.1"
 quoted-string = "0.2.2"


### PR DESCRIPTION
This crate doesn't compile with `cargo +nightly build -Z minimal-versions`, because unicase v2.0.0 indirectly depends on semver v0.1.0, which doesn't work with Rust 1.x.


