### PR TITLE
range: ensure plain media matches with parametrized form

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -340,6 +340,9 @@ mod tests {
 
         let many_params = MediaType::parse("text/plain; charset=utf-8; foo=bar").unwrap();
         assert!(text_any_utf8.matches(&many_params));
+
+        let text_plain = MediaRange::parse("text/plain").unwrap();
+        assert!(text_plain.matches(&many_params));
     }
 
     #[test]


### PR DESCRIPTION
This adds a test assertion to make sure that a non-parametrized
media type can be used to match over any of its parametrized forms.