### PR TITLE
mediatype: add helper for stripping parameters

### DIFF
--- a/mime-parse/src/lib.rs
+++ b/mime-parse/src/lib.rs
@@ -133,6 +133,23 @@ impl Mime {
     }
 
     #[inline]
+    pub fn without_params(self) -> Self {
+        let semicolon = match self.semicolon() {
+            None => return self,
+            Some(i) => i,
+        };
+
+        let mut mtype = self;
+        mtype.params = ParamSource::None;
+        mtype.source = Atoms::intern(
+            &mtype.source.as_ref()[..semicolon],
+            mtype.slash,
+            InternParams::None,
+        );
+        mtype
+    }
+
+    #[inline]
     fn semicolon(&self) -> Option<usize> {
         match self.params {
             ParamSource::Utf8(i) |

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -186,6 +186,26 @@ impl MediaType {
         self.mime.has_params()
     }
 
+    /// Transforms the media type into its non-parametrized form.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let utf8: mime::MediaType = "text/html+xml; charset=utf-8".parse().unwrap();
+    /// assert_eq!(utf8.has_params(), true);
+    ///
+    /// let plain = utf8.without_params();
+    /// assert_eq!(plain.has_params(), false);
+    ///
+    /// let xml: mime::MediaType = "text/html+xml".parse().unwrap();
+    /// assert_eq!(plain, xml);
+    /// ```
+    #[inline]
+    pub fn without_params(self) -> Self {
+        let mut mtype = self;
+        mtype.mime = mtype.mime.without_params();
+        mtype
+    }
 
     #[cfg(test)]
     pub(super) fn test_assert_asterisks(&self) {


### PR DESCRIPTION
This adds `Mime` and `MediaType` helpers to consume an existing media
type into its non-parametrized form.