### PR TITLE
Fixes for deprecated code

### DIFF
--- a/mime-parse/src/lib.rs
+++ b/mime-parse/src/lib.rs
@@ -79,7 +79,7 @@ impl fmt::Debug for Byte {
             b'\t' => f.write_str("'\\t'"),
             b'\\' => f.write_str("'\\'"),
             b'\0' => f.write_str("'\\0'"),
-            0x20...0x7f => write!(f, "'{}'", self.0 as char),
+            0x20..=0x7f => write!(f, "'{}'", self.0 as char),
             _ => write!(f, "'\\x{:02x}'", self.0),
         }
     }

--- a/mime-parse/src/lib.rs
+++ b/mime-parse/src/lib.rs
@@ -86,24 +86,22 @@ impl fmt::Debug for Byte {
 }
 
 impl Error for ParseError {
-    fn description(&self) -> &str {
-        match self {
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let description = match self {
             ParseError::MissingSlash => "a slash (/) was missing between the type and subtype",
             ParseError::MissingEqual => "an equals sign (=) was missing between a parameter and its value",
             ParseError::MissingQuote => "a quote (\") was missing from a parameter value",
             ParseError::InvalidToken { .. } => "invalid token",
             ParseError::InvalidRange => "unexpected asterisk",
             ParseError::TooLong => "the string is too long",
-        }
-    }
-}
-
-impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        };
         if let ParseError::InvalidToken { pos, byte } = *self {
-            write!(f, "{}, {:?} at position {}", self.description(), byte, pos)
+            write!(f, "{}, {:?} at position {}", description, byte, pos)
         } else {
-            f.write_str(self.description())
+            f.write_str(description)
         }
     }
 }

--- a/mime-parse/src/rfc7231.rs
+++ b/mime-parse/src/rfc7231.rs
@@ -333,9 +333,9 @@ mod tests {
         for (i, &valid) in super::TOKEN_MAP.iter().enumerate() {
             let i = i as u8;
             let should = match i {
-                b'a'...b'z' |
-                b'A'...b'Z' |
-                b'0'...b'9' |
+                b'a'..=b'z' |
+                b'A'..=b'Z' |
+                b'0'..=b'9' |
                 b'!' |
                 b'#' |
                 b'$' |

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,13 +10,10 @@ pub struct InvalidMime {
 }
 
 impl Error for InvalidMime {
-    fn description(&self) -> &str {
-        "invalid MIME"
-    }
 }
 
 impl fmt::Display for InvalidMime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {}", self.description(), self.inner)
+        write!(f, "invalid MIME: {}", self.inner)
     }
 }


### PR DESCRIPTION
Error::description is deprecated and Rust will start emitting warnings about it soon