### PR TITLE
Add security multiparts for MIME (RFC 1847)

### DIFF
--- a/mime-parse/src/constants.rs
+++ b/mime-parse/src/constants.rs
@@ -330,7 +330,15 @@ impl Atoms {
                             if sub == OCTET_STREAM {
                                 return Atoms::APPLICATION_OCTET_STREAM;
                             }
-                        }
+                        },
+                        13 => {
+                            if sub == PGP_ENCRYPTED {
+                                return Atoms::APPLICATION_PGP_ENCRYPTED;
+                            }
+                            if sub == PGP_SIGNATURE {
+                                return Atoms::APPLICATION_PGP_SIGNATURE;
+                            }
+                        },
                         21 => {
                             if sub == WWW_FORM_URLENCODED {
                                 return Atoms::APPLICATION_WWW_FORM_URLENCODED;
@@ -407,12 +415,19 @@ names! {
     OCTET_STREAM, "octet-stream";
     PDF, "pdf";
 
+    // Security Multiparts for MIME (RFC 1847)
+    PGP_ENCRYPTED, "pgp-encrypted";
+    PGP_SIGNATURE, "pgp-signature";
+
     // common font/*
     WOFF, "woff";
     WOFF2, "woff2";
 
     // multipart/*
     FORM_DATA, "form-data";
+    // Security Multiparts for MIME (RFC 1847)
+    ENCRYPTED, "encrypted";
+    SIGNED, "signed";
 
     // common image/*
     BMP, "bmp";
@@ -466,6 +481,8 @@ mimes! {
     APPLICATION_MSGPACK, "application/msgpack", 11;
     APPLICATION_PDF, "application/pdf", 11;
     APPLICATION_DNS, "application/dns-message", 11;
+    APPLICATION_PGP_ENCRYPTED, "application/pgp-encrypted", 11;
+    APPLICATION_PGP_SIGNATURE, "application/pgp-signature", 11;
 
     // media-ranges
     //@ MediaRange:

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -109,6 +109,8 @@ mimes! {
     APPLICATION_MSGPACK, "application/msgpack";
     APPLICATION_PDF, "application/pdf";
     APPLICATION_DNS, "application/dns-message";
+    APPLICATION_PGP_ENCRYPTED, "application/pgp-encrypted";
+    APPLICATION_PGP_SIGNATURE, "application/pgp-signature";
 
     // media-ranges
     @ MediaRange:

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -122,6 +122,15 @@ mod tests {
     }
 
     #[test]
+    fn multipart_type_protocol_param() {
+        let me = media_type!("multipart/encrypted; protocol=\"application/pgp-encrypted\"");
+        assert_eq!(me.type_(), MULTIPART);
+        assert_eq!(me.subtype(), ENCRYPTED);
+        assert_eq!(me.param("protocol").unwrap(), &APPLICATION_PGP_ENCRYPTED.to_string()[..]);
+    }
+
+
+    #[test]
     fn media_type_lowercase() {
         let mt = media_type!("MULTIPART/FORM-DATA; BOUNDARY=AbCd");
         assert_eq!(mt.to_string(), "multipart/form-data; boundary=AbCd");


### PR DESCRIPTION
- Add `encrypted` multipart subtype
- Add `pgp-encrypted` application subtype
- Add `application/pgp-encrypted` type
- Add `signed` multipart subtype
- Add `pgp-signature` application subtype
- Add `application/pgp-signature` type

Closes #113.
updated version of #114 