### PR TITLE
Add constants for application/xml

### DIFF
--- a/mime-parse/src/constants.rs
+++ b/mime-parse/src/constants.rs
@@ -305,6 +305,9 @@ impl Atoms {
                             if sub == PDF {
                                 return Atoms::APPLICATION_PDF;
                             }
+                            if sub == XML {
+                                return Atoms::APPLICATION_XML;
+                            }
                         }
                         4 => {
                             if sub == JSON {
@@ -466,6 +469,7 @@ mimes! {
     APPLICATION_MSGPACK, "application/msgpack", 11;
     APPLICATION_PDF, "application/pdf", 11;
     APPLICATION_DNS, "application/dns-message", 11;
+    APPLICATION_XML, "application/xml", 11;
 
     // media-ranges
     //@ MediaRange:

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -109,6 +109,7 @@ mimes! {
     APPLICATION_MSGPACK, "application/msgpack";
     APPLICATION_PDF, "application/pdf";
     APPLICATION_DNS, "application/dns-message";
+    APPLICATION_XML, "application/xml";
 
     // media-ranges
     @ MediaRange:


### PR DESCRIPTION
This PR adds the constants `APPLICATION_XML = "application/xml"`, as listed in the [MDN docs of common mime types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).