### PR TITLE
Add AVIF and Webp mime types

### DIFF
--- a/mime-parse/src/constants.rs
+++ b/mime-parse/src/constants.rs
@@ -269,6 +269,9 @@ impl Atoms {
                             if sub == JPEG {
                                 return Atoms::IMAGE_JPEG;
                             }
+                            if sub == WEBP {
+                                return Atoms::IMAGE_WEBP;
+                            }
                         },
                         7 => {
                             if sub == SVG {
@@ -418,6 +421,7 @@ names! {
     BMP, "bmp";
     GIF, "gif";
     JPEG, "jpeg";
+    WEBP, "webp";
     PNG, "png";
     SVG, "svg+xml";
 
@@ -453,6 +457,7 @@ mimes! {
     IMAGE_GIF, "image/gif", 5;
     IMAGE_PNG, "image/png", 5;
     IMAGE_BMP, "image/bmp", 5;
+    IMAGE_WEBP, "image/webp", 5;
     IMAGE_SVG, "image/svg+xml", 5, Some(9);
 
     FONT_WOFF, "font/woff", 4;

--- a/mime-parse/src/constants.rs
+++ b/mime-parse/src/constants.rs
@@ -272,6 +272,9 @@ impl Atoms {
                             if sub == WEBP {
                                 return Atoms::IMAGE_WEBP;
                             }
+                            if sub == AVIF {
+                                return Atoms::IMAGE_AVIF;
+                            }
                         },
                         7 => {
                             if sub == SVG {
@@ -422,6 +425,7 @@ names! {
     GIF, "gif";
     JPEG, "jpeg";
     WEBP, "webp";
+    AVIF, "avif";
     PNG, "png";
     SVG, "svg+xml";
 
@@ -458,6 +462,7 @@ mimes! {
     IMAGE_PNG, "image/png", 5;
     IMAGE_BMP, "image/bmp", 5;
     IMAGE_WEBP, "image/webp", 5;
+    IMAGE_AVIF, "image/avif", 5;
     IMAGE_SVG, "image/svg+xml", 5, Some(9);
 
     FONT_WOFF, "font/woff", 4;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -97,6 +97,7 @@ mimes! {
     IMAGE_PNG, "image/png";
     IMAGE_BMP, "image/bmp";
     IMAGE_WEBP, "image/webp";
+    IMAGE_AVIF, "image/avif";
     IMAGE_SVG, "image/svg+xml";
 
     FONT_WOFF, "font/woff";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -96,6 +96,7 @@ mimes! {
     IMAGE_GIF, "image/gif";
     IMAGE_PNG, "image/png";
     IMAGE_BMP, "image/bmp";
+    IMAGE_WEBP, "image/webp";
     IMAGE_SVG, "image/svg+xml";
 
     FONT_WOFF, "font/woff";


### PR DESCRIPTION
AVIF and webp are two new image formats.

Fixes #123 