### PR TITLE
Implement/derive Eq+PartialEq for more types

### DIFF
--- a/mime-parse/src/lib.rs
+++ b/mime-parse/src/lib.rs
@@ -15,7 +15,7 @@ pub struct Parser {
     can_range: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Mime {
     source: Source,
     slash: u16,
@@ -23,7 +23,7 @@ pub struct Mime {
     params: ParamSource,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum Source {
     Atom(u8, &'static str),
     Dynamic(String),
@@ -41,7 +41,7 @@ impl AsRef<str> for Source {
 type Indexed = (u16, u16);
 type IndexedPair = (Indexed, Indexed);
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ParamSource {
     None,
     Utf8(u16),
@@ -50,12 +50,13 @@ pub enum ParamSource {
     Custom(u16, Vec<IndexedPair>),
 }
 
+#[derive(Debug, Eq, PartialEq)]
 pub enum InternParams {
     Utf8(usize),
     None,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ParseError {
     MissingSlash,
     MissingEqual,
@@ -68,7 +69,7 @@ pub enum ParseError {
     TooLong,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub struct Byte(u8);
 
 impl fmt::Debug for Byte {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use mime_parse::ParseError;
 
 /// An error type representing an invalid `MediaType` or `MediaRange`.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct InvalidMime {
     pub(crate) inner: ParseError,
 }

--- a/src/range.rs
+++ b/src/range.rs
@@ -274,6 +274,8 @@ impl PartialEq<MediaRange> for str {
     }
 }
 
+impl Eq for MediaRange {}
+
 impl FromStr for MediaRange {
     type Err = InvalidMime;
 

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -244,6 +244,8 @@ impl PartialEq<MediaType> for str {
     }
 }
 
+impl Eq for MediaType {}
+
 impl FromStr for MediaType {
     type Err = InvalidMime;
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -165,6 +165,8 @@ impl<'a> PartialEq<Value<'a>> for str {
     }
 }
 
+impl<'a> Eq for Value<'a> {}
+
 impl<'a> From<Value<'a>> for Cow<'a, str> {
     #[inline]
     fn from(value: Value<'a>) -> Self {


### PR DESCRIPTION
This PR is very similar to #128 and can replace it, because it also implements/derives Eq+PartialEq traits for more (I think all) public types. Reasons for this are the same as in #128, but I applied them to more types.

The main types where I think that is useful (apart from `Mime`) are `MediaType` and `MediaRange` (to allow `match`ing them and using them in structs that also want to implement `Eq`) and `ParseError` (to allow `matching` specific errors), but I hope adding Eq+PartialEq to more types won't hurt.