### PR TITLE
Add MimeIter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,13 @@ pub struct Mime {
     params: ParamSource,
 }
 
+/// An iterator of parsed mime
+#[derive(Clone, Debug)]
+pub struct MimeIter<'a> {
+    pos: usize,
+    source: &'a str,
+}
+
 /// A section of a `Mime`.
 ///
 /// For instance, for the Mime `image/svg+xml`, it contains 3 `Name`s,


### PR DESCRIPTION
This PR adds an iterator over mimes. The iterator returns the next Mime in the source string if it's parsed correctly or an error with the reference slice otherwise. It iterates over the string until it is fully consumed.
Is it better to return an error with the parsing error from the `parse()` function instead of the slice?