### PR TITLE
Add text/calendar mime-type

### DIFF
--- a/mime-parse/src/constants.rs
+++ b/mime-parse/src/constants.rs
@@ -438,6 +438,7 @@ mimes! {
     TEXT_PLAIN_UTF_8, "text/plain; charset=utf-8", 4, None, 10;
     TEXT_HTML, "text/html", 4;
     TEXT_HTML_UTF_8, "text/html; charset=utf-8", 4, None, 9;
+    TEXT_CALENDAR, "text/calendar", 4;
     TEXT_CSS, "text/css", 4;
     TEXT_CSS_UTF_8, "text/css; charset=utf-8", 4, None, 8;
     TEXT_JAVASCRIPT, "text/javascript", 4;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -81,6 +81,7 @@ mimes! {
     TEXT_PLAIN_UTF_8, "text/plain; charset=utf-8";
     TEXT_HTML, "text/html";
     TEXT_HTML_UTF_8, "text/html; charset=utf-8";
+    TEXT_CALENDAR, "text/calendar";
     TEXT_CSS, "text/css";
     TEXT_CSS_UTF_8, "text/css; charset=utf-8";
     TEXT_JAVASCRIPT, "text/javascript";


### PR DESCRIPTION
This mime-type is used extensively for CalDav and informally for WebDav.
It was originally defined in [rfc5545].
    
[rfc5545]: https://www.rfc-editor.org/rfc/rfc5545.html