### PR TITLE
fix: `MessagePack` subtype

### DIFF
--- a/mime-parse/src/constants.rs
+++ b/mime-parse/src/constants.rs
@@ -403,7 +403,7 @@ names! {
     // common application/*
     JSON, "json";
     WWW_FORM_URLENCODED, "x-www-form-urlencoded";
-    MSGPACK, "msgpack";
+    MSGPACK, "vnd.msgpack";
     OCTET_STREAM, "octet-stream";
     PDF, "pdf";
 
@@ -463,7 +463,7 @@ mimes! {
     APPLICATION_JAVASCRIPT_UTF_8, "application/javascript; charset=utf-8", 11, None, 22;
     APPLICATION_WWW_FORM_URLENCODED, "application/x-www-form-urlencoded", 11;
     APPLICATION_OCTET_STREAM, "application/octet-stream", 11;
-    APPLICATION_MSGPACK, "application/msgpack", 11;
+    APPLICATION_MSGPACK, "application/vnd.msgpack", 11;
     APPLICATION_PDF, "application/pdf", 11;
     APPLICATION_DNS, "application/dns-message", 11;
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -106,7 +106,7 @@ mimes! {
     APPLICATION_JAVASCRIPT_UTF_8, "application/javascript; charset=utf-8";
     APPLICATION_WWW_FORM_URLENCODED, "application/x-www-form-urlencoded";
     APPLICATION_OCTET_STREAM, "application/octet-stream";
-    APPLICATION_MSGPACK, "application/msgpack";
+    APPLICATION_MSGPACK, "application/vnd.msgpack";
     APPLICATION_PDF, "application/pdf";
     APPLICATION_DNS, "application/dns-message";
 


### PR DESCRIPTION
### Overview

Changed `msgpack` subtype to `vnd.msgpack`.

### Why I did it

- [MessagePack page on iana.org](https://www.iana.org/assignments/media-types/application/vnd.msgpack)
- Completed issue on `msgpack` repo: https://github.com/msgpack/msgpack/issues/194#issuecomment-2111445791

### Additional Information

Closes #157