### PR TITLE
Upgrade to rust 2024 edition and enable more functionality at compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Strongly Typed Mimes"
 documentation = "https://docs.rs/mime"
 repository = "https://github.com/hyperium/mime"
 keywords = ["mime", "media-extensions", "media-types"]
-edition = "2018"
+edition = "2024"
 
 publish = false # breaking changes from 0.3.x
 

--- a/mime-macro/Cargo.toml
+++ b/mime-macro/Cargo.toml
@@ -6,7 +6,7 @@ description = "mime procedural macros"
 repository = "https://github.com/hyperium/mime"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 license = "MIT"
-edition = "2018"
+edition = "2024"
 
 [lib]
 name = "mime_macro"

--- a/mime-parse/Cargo.toml
+++ b/mime-parse/Cargo.toml
@@ -6,4 +6,4 @@ description = "mime parsing internals"
 repository = "https://github.com/hyperium/mime"
 authors = ["Sean McArthur <sean@seanmonstar.com>"]
 license = "MIT"
-edition = "2018"
+edition = "2024"

--- a/mime-parse/src/constants.rs
+++ b/mime-parse/src/constants.rs
@@ -166,10 +166,8 @@ impl Atoms {
                 return Atoms::TEXT_TAB_SEPARATED_VALUES_UTF_8;
             }
         }
-        if top == APPLICATION {
-            if sub == JAVASCRIPT {
-                return Atoms::APPLICATION_JAVASCRIPT_UTF_8;
-            }
+        if top == APPLICATION && sub == JAVASCRIPT {
+            return Atoms::APPLICATION_JAVASCRIPT_UTF_8;
         }
 
         Atoms::dynamic(s)
@@ -184,10 +182,8 @@ impl Atoms {
             4 => {
                 if top == TEXT {
                     match sub.len() {
-                        1 => {
-                            if sub.as_bytes()[0] == b'*' {
-                                return Atoms::TEXT_STAR;
-                            }
+                        1 if sub.as_bytes()[0] == b'*' => {
+                            return Atoms::TEXT_STAR;
                         }
                         3 => {
                             if sub == CSS {
@@ -200,10 +196,8 @@ impl Atoms {
                                 return Atoms::TEXT_CSV;
                             }
                         },
-                        4 => {
-                            if sub == HTML {
-                                return Atoms::TEXT_HTML;
-                            }
+                        4 if sub == HTML => {
+                            return Atoms::TEXT_HTML;
                         }
                         5 => {
                             if sub == PLAIN {
@@ -213,34 +207,24 @@ impl Atoms {
                                 return Atoms::TEXT_VCARD;
                             }
                         }
-                        10 => {
-                            if sub == JAVASCRIPT {
-                                return Atoms::TEXT_JAVASCRIPT;
-                            }
+                        10 if sub == JAVASCRIPT => {
+                            return Atoms::TEXT_JAVASCRIPT;
                         }
-                        12 => {
-                            if sub == EVENT_STREAM {
-                                return Atoms::TEXT_EVENT_STREAM;
-                            }
+                        12 if sub == EVENT_STREAM => {
+                            return Atoms::TEXT_EVENT_STREAM;
                         },
-                        20 => {
-                            if sub == TAB_SEPARATED_VALUES {
-                                return Atoms::TEXT_TAB_SEPARATED_VALUES;
-                            }
+                        20 if sub == TAB_SEPARATED_VALUES => {
+                            return Atoms::TEXT_TAB_SEPARATED_VALUES;
                         }
                         _ => (),
                     }
                 } else if top == FONT {
                     match sub.len() {
-                        4 => {
-                            if sub == WOFF {
-                                return Atoms::FONT_WOFF;
-                            }
+                        4 if sub == WOFF => {
+                            return Atoms::FONT_WOFF;
                         },
-                        5 => {
-                            if sub == WOFF2 {
-                                return Atoms::FONT_WOFF2;
-                            }
+                        5 if sub == WOFF2 => {
+                            return Atoms::FONT_WOFF2;
                         },
                         _ => (),
                     }
@@ -249,10 +233,8 @@ impl Atoms {
             5 => {
                 if top == IMAGE {
                     match sub.len() {
-                        1 => {
-                            if sub.as_bytes()[0] == b'*' {
-                                return Atoms::IMAGE_STAR;
-                            }
+                        1 if sub.as_bytes()[0] == b'*' => {
+                            return Atoms::IMAGE_STAR;
                         }
                         3 => {
                             if sub == PNG {
@@ -265,79 +247,49 @@ impl Atoms {
                                 return Atoms::IMAGE_BMP;
                             }
                         }
-                        4 => {
-                            if sub == JPEG {
-                                return Atoms::IMAGE_JPEG;
-                            }
+                        4 if sub == JPEG => {
+                            return Atoms::IMAGE_JPEG;
                         },
-                        7 => {
-                            if sub == SVG {
-                                return Atoms::IMAGE_SVG;
-                            }
+                        7 if sub == SVG => {
+                            return Atoms::IMAGE_SVG;
                         },
                         _ => (),
 
                     }
-                } else if top == VIDEO {
-                    match sub.len() {
-                        1 => {
-                            if sub.as_bytes()[0] == b'*' {
-                                return Atoms::VIDEO_STAR;
-                            }
-                        },
-                        _ => (),
-                    }
-                } else if top == AUDIO {
-                    match sub.len() {
-                        1 => {
-                            if sub.as_bytes()[0] == b'*' {
-                                return Atoms::AUDIO_STAR;
-                            }
-                        },
-                        _ => (),
-                    }
+                } else if top == VIDEO
+                    && sub.len() == 1 && sub.as_bytes()[0] == b'*'
+                {
+                    return Atoms::VIDEO_STAR;
+                } else if top == AUDIO
+                    && sub.len() == 1 && sub.as_bytes()[0] == b'*'
+                {
+                    return Atoms::AUDIO_STAR;
                 }
             },
-            11 => {
-                if top == APPLICATION {
-                    match sub.len() {
-                        3 => {
-                            if sub == PDF {
-                                return Atoms::APPLICATION_PDF;
-                            }
-                        }
-                        4 => {
-                            if sub == JSON {
-                                return Atoms::APPLICATION_JSON;
-                            }
-                        },
-                        7 => {
-                            if sub == MSGPACK {
-                                return Atoms::APPLICATION_MSGPACK;
-                            }
-                        },
-                        10 => {
-                            if sub == JAVASCRIPT {
-                                return Atoms::APPLICATION_JAVASCRIPT;
-                            }
-                        },
-                        11 => {
-                            if sub == "dns-message" {
-                                return Atoms::APPLICATION_DNS;
-                            }
-                        },
-                        12 => {
-                            if sub == OCTET_STREAM {
-                                return Atoms::APPLICATION_OCTET_STREAM;
-                            }
-                        }
-                        21 => {
-                            if sub == WWW_FORM_URLENCODED {
-                                return Atoms::APPLICATION_WWW_FORM_URLENCODED;
-                            }
-                        }
-                        _ => (),
+            11 if top == APPLICATION => {
+                match sub.len() {
+                    3 if sub == PDF => {
+                        return Atoms::APPLICATION_PDF;
                     }
+                    4 if sub == JSON => {
+                        return Atoms::APPLICATION_JSON;
+                    },
+                    7 if sub == MSGPACK => {
+                        return Atoms::APPLICATION_MSGPACK;
+                    },
+                    10 if sub == JAVASCRIPT => {
+                        return Atoms::APPLICATION_JAVASCRIPT;
+                    },
+                    11 if sub == "dns-message" => {
+                        return Atoms::APPLICATION_DNS;
+                    },
+                    12 if sub == OCTET_STREAM => {
+                        return Atoms::APPLICATION_OCTET_STREAM;
+                    }
+                    21 if sub == WWW_FORM_URLENCODED => {
+                        return Atoms::APPLICATION_WWW_FORM_URLENCODED;
+                    }
+                    _ => (),
                 }
             }
             _ => (),

--- a/mime-parse/src/lib.rs
+++ b/mime-parse/src/lib.rs
@@ -117,7 +117,7 @@ impl fmt::Display for ParseError {
 impl Mime {
     #[inline]
     pub const fn type_(&self) -> &str {
-        &self.source.const_as_ref().split_at(self.slash as usize).0
+        self.source.const_as_ref().split_at(self.slash as usize).0
     }
 
     #[inline]
@@ -223,7 +223,7 @@ impl Mime {
     }
 
     pub const fn essence(&self) -> &str {
-        &self.source.const_as_ref().split_at(self.semicolon_or_end()).0
+        self.source.const_as_ref().split_at(self.semicolon_or_end()).0
     }
 
     #[doc(hidden)]
@@ -272,7 +272,7 @@ impl fmt::Display for Mime {
 
 #[inline]
 const fn as_u16(i: usize) -> u16 {
-    debug_assert!(i <= std::u16::MAX as usize, "as_u16 overflow");
+    debug_assert!(i <= u16::MAX as usize, "as_u16 overflow");
     i as u16
 }
 
@@ -414,19 +414,19 @@ mod sealed {
 
 pub trait Parse: Sealed {}
 
-impl<'a> Sealed for &'a str {
+impl Sealed for &str {
     fn as_str(&self) -> &str {
         self
     }
 }
 
-impl<'a> Parse for &'a str {}
+impl Parse for &str {}
 
-impl<'a> Sealed for &'a String {
+impl Sealed for &String {
     fn as_str(&self) -> &str {
-        *self
+        self
     }
 }
 
-impl<'a> Parse for &'a String {}
+impl Parse for &String {}
 

--- a/mime-parse/src/lib.rs
+++ b/mime-parse/src/lib.rs
@@ -29,12 +29,18 @@ pub enum Source {
     Dynamic(String),
 }
 
-impl AsRef<str> for Source {
-    fn as_ref(&self) -> &str {
+impl Source {
+    const fn const_as_ref(&self) -> &str {
         match *self {
             Source::Atom(_, s) => s,
-            Source::Dynamic(ref s) => s,
+            Source::Dynamic(ref s) => s.as_str(),
         }
+    }
+}
+
+impl AsRef<str> for Source {
+    fn as_ref(&self) -> &str {
+        self.const_as_ref()
     }
 }
 
@@ -110,29 +116,29 @@ impl fmt::Display for ParseError {
 
 impl Mime {
     #[inline]
-    pub fn type_(&self) -> &str {
-        &self.source.as_ref()[..self.slash as usize]
+    pub const fn type_(&self) -> &str {
+        &self.source.const_as_ref().split_at(self.slash as usize).0
     }
 
     #[inline]
     pub fn subtype(&self) -> &str {
         let end = self.semicolon_or_end();
-        &self.source.as_ref()[self.slash as usize + 1..end]
+        &self.source.const_as_ref()[self.slash as usize + 1..end]
     }
 
     #[doc(hidden)]
-    pub fn private_subtype_offset(&self) -> u16 {
+    pub const fn private_subtype_offset(&self) -> u16 {
         self.slash
     }
 
     #[inline]
     pub fn suffix(&self) -> Option<&str> {
         let end = self.semicolon_or_end();
-        self.plus.map(|idx| &self.source.as_ref()[idx as usize + 1..end])
+        self.plus.map(|idx| &self.source.const_as_ref()[idx as usize + 1..end])
     }
 
     #[doc(hidden)]
-    pub fn private_suffix_offset(&self) -> Option<u16> {
+    pub const fn private_suffix_offset(&self) -> Option<u16> {
         self.plus
     }
 
@@ -155,7 +161,7 @@ impl Mime {
     }
 
     #[doc(hidden)]
-    pub fn private_params_source(&self) -> &ParamSource {
+    pub const fn private_params_source(&self) -> &ParamSource {
         &self.params
     }
 
@@ -164,7 +170,7 @@ impl Mime {
     }
 
     #[inline]
-    pub fn has_params(&self) -> bool {
+    pub const fn has_params(&self) -> bool {
         self.semicolon().is_some()
     }
 
@@ -178,7 +184,7 @@ impl Mime {
         let mut mtype = self;
         mtype.params = ParamSource::None;
         mtype.source = Atoms::intern(
-            &mtype.source.as_ref()[..semicolon],
+            &mtype.source.const_as_ref()[..semicolon],
             mtype.slash,
             InternParams::None,
         );
@@ -186,7 +192,7 @@ impl Mime {
     }
 
     #[inline]
-    fn semicolon(&self) -> Option<usize> {
+    const fn semicolon(&self) -> Option<usize> {
         match self.params {
             ParamSource::Utf8(i) |
             ParamSource::One(i, ..) |
@@ -197,24 +203,27 @@ impl Mime {
     }
 
     #[inline]
-    fn semicolon_or_end(&self) -> usize {
-        self.semicolon().unwrap_or_else(|| self.source.as_ref().len())
+    const fn semicolon_or_end(&self) -> usize {
+        match self.semicolon() {
+            Some(s) => s,
+            None => self.source.const_as_ref().len(),
+        }
     }
 
     #[doc(hidden)]
-    pub fn private_atom(&self) -> u8 {
+    pub const fn private_atom(&self) -> u8 {
         self.atom()
     }
 
-    fn atom(&self) -> u8 {
+    const fn atom(&self) -> u8 {
         match self.source {
             Source::Atom(a, _) => a,
             Source::Dynamic(_) => 0,
         }
     }
 
-    pub fn essence(&self) -> &str {
-        &self.source.as_ref()[..self.semicolon_or_end()]
+    pub const fn essence(&self) -> &str {
+        &self.source.const_as_ref().split_at(self.semicolon_or_end()).0
     }
 
     #[doc(hidden)]
@@ -233,10 +242,17 @@ impl Mime {
     }
 }
 
+impl Mime {
+    #[inline]
+    pub const fn const_as_ref(&self) -> &str {
+        self.source.const_as_ref()
+    }
+}
+
 impl AsRef<str> for Mime {
     #[inline]
     fn as_ref(&self) -> &str {
-        self.source.as_ref()
+        self.const_as_ref()
     }
 }
 
@@ -255,13 +271,13 @@ impl fmt::Display for Mime {
 }
 
 #[inline]
-fn as_u16(i: usize) -> u16 {
+const fn as_u16(i: usize) -> u16 {
     debug_assert!(i <= std::u16::MAX as usize, "as_u16 overflow");
     i as u16
 }
 
 #[inline]
-fn range(index: (u16, u16)) -> std::ops::Range<usize> {
+const fn range(index: (u16, u16)) -> std::ops::Range<usize> {
     index.0 as usize .. index.1 as usize
 }
 
@@ -269,14 +285,14 @@ fn range(index: (u16, u16)) -> std::ops::Range<usize> {
 
 impl Parser {
     #[inline]
-    pub fn can_range() -> Self {
+    pub const fn can_range() -> Self {
         Parser {
             can_range: true,
         }
     }
 
     #[inline]
-    pub fn cannot_range() -> Self {
+    pub const fn cannot_range() -> Self {
         Parser {
             can_range: false,
         }

--- a/mime-parse/src/rfc7231.rs
+++ b/mime-parse/src/rfc7231.rs
@@ -314,11 +314,11 @@ static TOKEN_MAP: [bool; 256] = byte_map![
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ];
 
-fn is_token(c: u8) -> bool {
+const fn is_token(c: u8) -> bool {
     TOKEN_MAP[c as usize]
 }
 
-fn is_restricted_quoted_char(c: u8) -> bool {
+const fn is_restricted_quoted_char(c: u8) -> bool {
     c == 9 || (c > 31 && c != 127)
 }
 

--- a/mime-parse/src/rfc7231.rs
+++ b/mime-parse/src/rfc7231.rs
@@ -53,7 +53,7 @@ use crate::{
 
 pub(crate) fn parse(opts: &Parser, src: impl Parse) -> Result<Mime, ParseError> {
     let s = src.as_str();
-    if s.len() > std::u16::MAX as usize {
+    if s.len() > u16::MAX as usize {
         return Err(ParseError::TooLong);
     }
 
@@ -79,7 +79,7 @@ pub(crate) fn parse(opts: &Parser, src: impl Parse) -> Result<Mime, ParseError> 
             },
             None => return Err(ParseError::MissingSlash), // EOF and no toplevel is no Mime
             Some((pos, byte)) => return Err(ParseError::InvalidToken {
-                pos: pos,
+                pos,
                 byte: Byte(byte),
             }),
         };
@@ -131,7 +131,7 @@ pub(crate) fn parse(opts: &Parser, src: impl Parse) -> Result<Mime, ParseError> 
                 });
             },
             Some((pos, byte)) => return Err(ParseError::InvalidToken {
-                pos: pos,
+                pos,
                 byte: Byte(byte),
             })
         };
@@ -193,7 +193,7 @@ fn params_from_str(s: &str, iter: &mut impl Iterator<Item=(usize, u8)>, mut star
                 },
                 None => return Err(ParseError::MissingEqual),
                 Some((pos, byte)) => return Err(ParseError::InvalidToken {
-                    pos: pos,
+                    pos,
                     byte: Byte(byte),
                 }),
             }
@@ -211,7 +211,7 @@ fn params_from_str(s: &str, iter: &mut impl Iterator<Item=(usize, u8)>, mut star
                     match iter.next() {
                         Some((_, ch)) if is_restricted_quoted_char(ch) => (),
                         Some((pos, byte)) => return Err(ParseError::InvalidToken {
-                            pos: pos,
+                            pos,
                             byte: Byte(byte),
                         }),
                         None => return Err(ParseError::MissingQuote),
@@ -228,7 +228,7 @@ fn params_from_str(s: &str, iter: &mut impl Iterator<Item=(usize, u8)>, mut star
                         Some((_, c)) if is_restricted_quoted_char(c) => (),
                         None => return Err(ParseError::MissingQuote),
                         Some((pos, byte)) => return Err(ParseError::InvalidToken {
-                            pos: pos,
+                            pos,
                             byte: Byte(byte),
                         }),
                     }
@@ -253,7 +253,7 @@ fn params_from_str(s: &str, iter: &mut impl Iterator<Item=(usize, u8)>, mut star
                     },
 
                     Some((pos, byte)) => return Err(ParseError::InvalidToken {
-                        pos: pos,
+                        pos,
                         byte: Byte(byte),
                     }),
                 }

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -9,7 +9,7 @@ pub(crate) fn str_eq(mime: &Mime, s: &str) -> bool {
             })
             .unwrap_or(false)
     } else {
-        mime.as_ref().eq_ignore_ascii_case(s)
+        mime.const_as_ref().eq_ignore_ascii_case(s)
     }
 }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -68,7 +68,7 @@ impl MediaRange {
     /// assert_eq!(range.type_(), mime::TEXT);
     /// ```
     #[inline]
-    pub fn type_(&self) -> &str {
+    pub const fn type_(&self) -> &str {
         self.mime.type_()
     }
 
@@ -215,7 +215,7 @@ impl MediaRange {
     /// assert_eq!(plain_text_utf8.has_params(), true);
     /// ```
     #[inline]
-    pub fn has_params(&self) -> bool {
+    pub const fn has_params(&self) -> bool {
         self.mime.has_params()
     }
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -260,7 +260,7 @@ impl<'a> PartialEq<&'a str> for MediaRange {
     }
 }
 
-impl<'a> PartialEq<MediaRange> for &'a str {
+impl PartialEq<MediaRange> for &str {
     #[inline]
     fn eq(&self, mr: &MediaRange) -> bool {
         mr == self

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -209,6 +209,18 @@ impl MediaType {
     pub(super) fn test_assert_asterisks(&self) {
         assert!(!self.as_ref().contains('*'), "{:?} contains an asterisk", self);
     }
+
+    /// Converts this type into a shared string slice reference
+    #[doc(alias = "as_ref")]
+    pub const fn const_as_ref(&self) -> &str {
+        self.mime.const_as_ref()
+    }
+}
+
+impl AsRef<str> for MediaType {
+    fn as_ref(&self) -> &str {
+        self.const_as_ref()
+    }
 }
 
 impl PartialEq for MediaType {
@@ -249,12 +261,6 @@ impl FromStr for MediaType {
 
     fn from_str(s: &str) -> Result<MediaType, Self::Err> {
         MediaType::parse(s)
-    }
-}
-
-impl AsRef<str> for MediaType {
-    fn as_ref(&self) -> &str {
-        self.mime.as_ref()
     }
 }
 

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -85,7 +85,7 @@ impl MediaType {
     /// assert_eq!(mime.type_(), mime::TEXT);
     /// ```
     #[inline]
-    pub fn type_(&self) -> &str {
+    pub const fn type_(&self) -> &str {
         self.mime.type_()
     }
 
@@ -180,7 +180,7 @@ impl MediaType {
     /// assert_eq!(plain_text_utf8.has_params(), true);
     /// ```
     #[inline]
-    pub fn has_params(&self) -> bool {
+    pub const fn has_params(&self) -> bool {
         self.mime.has_params()
     }
 

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -223,14 +223,14 @@ impl PartialEq<str> for MediaType {
     }
 }
 
-impl<'a> PartialEq<&'a str> for MediaType {
+impl PartialEq<&str> for MediaType {
     #[inline]
-    fn eq(&self, s: & &'a str) -> bool {
+    fn eq(&self, s: & &str) -> bool {
         self == *s
     }
 }
 
-impl<'a> PartialEq<MediaType> for &'a str {
+impl PartialEq<MediaType> for &str {
     #[inline]
     fn eq(&self, mt: &MediaType) -> bool {
         mt == self

--- a/src/value.rs
+++ b/src/value.rs
@@ -38,7 +38,7 @@ pub(crate) fn param<'a>(mime: &'a Mime, key: &str) -> Option<Value<'a>> {
 }
 
 impl<'a> Value<'a> {
-    fn new(source: &'a str) -> Self {
+    const fn new(source: &'a str) -> Self {
         Value {
             source,
             ascii_case_insensitive: false,
@@ -69,7 +69,7 @@ impl<'a> Value<'a> {
     /// let param = mime.param("param").unwrap();
     /// assert_eq!(param.as_str_repr(), r#""abc def""#);
     /// ```
-    pub fn as_str_repr(&self) -> &'a str {
+    pub const fn as_str_repr(&self) -> &'a str {
         self.source
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -151,7 +151,7 @@ impl<'a, 'b> PartialEq<&'b str> for Value<'a> {
 }
 
 
-impl<'a, 'b> PartialEq<Value<'b>> for &'a str {
+impl<'b> PartialEq<Value<'b>> for &str {
     #[inline]
     fn eq(&self, other: &Value<'b>) -> bool {
         other == self


### PR DESCRIPTION
This patch
- Upgrades to rust 2024 edition
- Enables more functionality at compile time, with `const fn`
- And cleans up the codebase to conform to 2024 edition idioms